### PR TITLE
Signals performance work

### DIFF
--- a/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
+++ b/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
@@ -183,15 +183,17 @@ namespace Fiber
     {
         private DynamicDependencies<T> _dynamicSignals;
         bool _hasRun = false;
+        private byte _lastDirtyBit;
 
         public DynamicEffect(IList<ISignal<T>> signals, bool runOnMount = true)
         {
-            _dynamicSignals = new DynamicDependencies<T>(this, signals, runOnMount);
+            _dynamicSignals = new DynamicDependencies<T>(this, signals);
+            _lastDirtyBit = (byte)(_dirtyBit - (runOnMount ? 1 : 0));
         }
 
         public sealed override void RunIfDirty()
         {
-            if (_dynamicSignals.IsDirty())
+            if (_lastDirtyBit != _dirtyBit)
             {
                 if (_hasRun)
                 {
@@ -199,6 +201,8 @@ namespace Fiber
                 }
                 Run(_dynamicSignals);
                 _hasRun = true;
+
+                _lastDirtyBit = _dirtyBit;
             }
         }
 

--- a/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
+++ b/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
@@ -1599,7 +1599,7 @@ namespace Fiber
 
     public class Renderer : IComponentAPI, IEffectAPI
     {
-        public const long DEFAULT_WORK_LOOP_TIME_BUDGET_MS = 5;
+        public const long DEFAULT_WORK_LOOP_TIME_BUDGET_MS = 4;
 
         private Queue<FiberNode> _renderQueue;
         private MixedQueue _operationsQueue;

--- a/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
+++ b/Assets/Fiber/Packages/Fiber/Runtime/Fiber.cs
@@ -28,8 +28,6 @@ namespace Fiber
         public abstract void Update();
         public abstract void Cleanup();
         public abstract void SetVisible(bool visible);
-        protected override sealed void OnNotifySignalUpdate() { }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public interface IComponentAPI
@@ -159,8 +157,6 @@ namespace Fiber
 
         public abstract void RunIfDirty();
         public abstract void Cleanup();
-        protected override sealed void OnNotifySignalUpdate() { }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public abstract class Effect : BaseEffect
@@ -1364,6 +1360,7 @@ namespace Fiber
             Phase = FiberNodePhase.AddedToVirtualTree;
             IsEnabled = true;
             _virtualNodeType = VirtualNode?.Type ?? VirtualNodeType.Null;
+            _signalType = SignalType.FiberNode;
         }
 
         public void PushEffect(BaseEffect effect)
@@ -1573,13 +1570,12 @@ namespace Fiber
             }
         }
 
-        protected override sealed void OnNotifySignalUpdate()
+        protected override void OnNotifySignalUpdate()
         {
             // OPEN POINT: We could optimize this to see if already in queue.
             // Keeping it like this for now for simplicity reasons.
             _renderer.AddFiberNodeToUpdateQueue(this);
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
 
         public void TryDisposeVirtualNode()
         {

--- a/Assets/Fiber/Packages/FiberRouter/Runtime/FiberRouter.cs
+++ b/Assets/Fiber/Packages/FiberRouter/Runtime/FiberRouter.cs
@@ -68,8 +68,6 @@ namespace Fiber.Router
                 var route = routeStack[routeStack.Count - 1];
                 return route;
             }
-
-            protected override bool ShouldSetDirty(Route newValue, Route previousValue) => !newValue.Equals(previousValue);
         }
 
         private class CurrentModalSignal_Implementation : ComputedSignal<Route, ModalRoute>
@@ -80,8 +78,6 @@ namespace Fiber.Router
                 var modalRoute = currentRoute.PeekModal();
                 return modalRoute;
             }
-
-            protected override bool ShouldSetDirty(ModalRoute newValue, ModalRoute previousValue) => !newValue.Equals(previousValue);
         }
 
         public RouteDefinition RouterTree { get; private set; }

--- a/Assets/Fiber/Packages/FiberRouter/Runtime/FiberRouter.cs
+++ b/Assets/Fiber/Packages/FiberRouter/Runtime/FiberRouter.cs
@@ -320,16 +320,7 @@ namespace Fiber.Router
             return ModalRoute.Empty();
         }
 
-        public override sealed bool IsDirty(byte otherDirtyBit)
-        {
-            return otherDirtyBit != DirtyBit;
-        }
         public override Router Get() => this;
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 
     public abstract class BaseRouteComponent : BaseComponent

--- a/Assets/Fiber/Packages/FiberUIElements/Runtime/FiberUIElements.Scaling.cs
+++ b/Assets/Fiber/Packages/FiberUIElements/Runtime/FiberUIElements.Scaling.cs
@@ -120,9 +120,7 @@ namespace Fiber.UIElements
             return (dpWidth, dpHeight);
         }
 
-        protected override sealed void OnNotifySignalUpdate() { _dirtyBit++; }
         public override sealed ScreenSize Get() => _value;
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public class ScalingConfig

--- a/Assets/Fiber/Packages/Signals/Runtime/ComputedSignals.cs
+++ b/Assets/Fiber/Packages/Signals/Runtime/ComputedSignals.cs
@@ -14,13 +14,6 @@ namespace Signals
 
         protected virtual void Cleanup(RT previousValue) { }
         protected virtual bool ShouldSetDirty(RT newValue, RT previousValue) => true;
-
-        protected override sealed void OnNotifySignalUpdate() { }
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            Get(); // We need to run the signal in order to update the dirty bit
-            return DirtyBit != otherDirtyBit;
-        }
     }
 
     [Serializable]

--- a/Assets/Fiber/Packages/Signals/Runtime/SignalSubscribtionManager.cs
+++ b/Assets/Fiber/Packages/Signals/Runtime/SignalSubscribtionManager.cs
@@ -34,6 +34,7 @@ namespace Signals
             {
                 _onChange(_signal1.Get());
             }
+            _signalType = SignalType.Subscription;
         }
 
         protected override void OnNotifySignalUpdate()
@@ -53,7 +54,6 @@ namespace Signals
         {
             _signal1.UnregisterDependent(this);
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public class SignalSubscription<T1, T2> : BaseSignal, ISignalSubscription
@@ -86,6 +86,8 @@ namespace Signals
             {
                 _onChange(_signal1.Get(), _signal2.Get());
             }
+
+            _signalType = SignalType.Subscription;
         }
 
         protected override void OnNotifySignalUpdate()
@@ -108,7 +110,6 @@ namespace Signals
             _signal1.UnregisterDependent(this);
             _signal2.UnregisterDependent(this);
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public class SignalSubscription<T1, T2, T3> : BaseSignal, ISignalSubscription
@@ -147,6 +148,8 @@ namespace Signals
             {
                 _onChange(_signal1.Get(), _signal2.Get(), _signal3.Get());
             }
+
+            _signalType = SignalType.Subscription;
         }
 
         protected override void OnNotifySignalUpdate()
@@ -172,7 +175,6 @@ namespace Signals
             _signal2.UnregisterDependent(this);
             _signal3.UnregisterDependent(this);
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public class SignalSubscription<T1, T2, T3, T4> : BaseSignal, ISignalSubscription
@@ -217,6 +219,8 @@ namespace Signals
             {
                 _onChange(_signal1.Get(), _signal2.Get(), _signal3.Get(), _signal4.Get());
             }
+
+            _signalType = SignalType.Subscription;
         }
 
         protected override void OnNotifySignalUpdate()
@@ -245,7 +249,6 @@ namespace Signals
             _signal3.UnregisterDependent(this);
             _signal4.UnregisterDependent(this);
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     // Manager class that lets you subscribe to changes to signals.

--- a/Assets/Fiber/Packages/Signals/Runtime/Signals.cs
+++ b/Assets/Fiber/Packages/Signals/Runtime/Signals.cs
@@ -125,6 +125,11 @@ namespace Signals
         {
             return DirtyBit != otherDirtyBit;
         }
+
+        public void SetDirty()
+        {
+            _dirtyBit++;
+        }
     }
 
     [Serializable]

--- a/Assets/Fiber/Packages/Signals/Runtime/Signals.cs
+++ b/Assets/Fiber/Packages/Signals/Runtime/Signals.cs
@@ -36,6 +36,13 @@ namespace Signals
         T GetAt(int index);
     }
 
+    public enum SignalType
+    {
+        Default = 0,
+        FiberNode = 1,
+        Subscription = 2,
+    }
+
     [Serializable]
     public abstract class BaseSignal : ISignal
     {
@@ -44,6 +51,7 @@ namespace Signals
         [SerializeField]
         protected byte _dirtyBit = 0;
         public byte DirtyBit => _dirtyBit;
+        protected SignalType _signalType = SignalType.Default;
 
         ~BaseSignal()
         {
@@ -53,11 +61,17 @@ namespace Signals
             }
         }
 
-        protected abstract void OnNotifySignalUpdate();
+        protected virtual void OnNotifySignalUpdate() { }
 
         public void NotifySignalUpdate()
         {
-            OnNotifySignalUpdate();
+            _dirtyBit++;
+
+            if (_signalType != SignalType.Default)
+            {
+                OnNotifySignalUpdate();
+            }
+
             if (_dependents != null)
             {
                 if (_dependents is List<ISignal> listOfDependents)
@@ -107,42 +121,16 @@ namespace Signals
             }
         }
 
-        public abstract bool IsDirty(byte otherDirtyBit);
+        public bool IsDirty(byte otherDirtyBit)
+        {
+            return DirtyBit != otherDirtyBit;
+        }
     }
 
     [Serializable]
     public abstract class BaseSignal<T> : BaseSignal, ISignal<T>
     {
         public abstract T Get();
-    }
-
-    public class NullableSignal<T, ST> : BaseSignal<T>
-        where ST : BaseSignal<T>
-    {
-        private ST _wrappedSignal;
-        public NullableSignal(ST wrappedSignal)
-        {
-            _wrappedSignal = wrappedSignal;
-            if (_wrappedSignal != null)
-            {
-                _wrappedSignal.RegisterDependent(this);
-            }
-        }
-
-        ~NullableSignal()
-        {
-            if (_wrappedSignal != null)
-            {
-                _wrappedSignal.UnregisterDependent(this);
-            }
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-        public override sealed T Get() => _wrappedSignal == null ? default : _wrappedSignal.Get();
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     [Serializable]
@@ -166,12 +154,7 @@ namespace Signals
             _dependents = dependent;
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
         public override sealed T Get() => _value;
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     [Serializable]
@@ -216,12 +199,7 @@ namespace Signals
             }
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
         public override sealed T Get() => _value;
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     [Serializable]
@@ -349,16 +327,10 @@ namespace Signals
             return _list.GetEnumerator();
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-
         public override sealed IList<T> Get()
         {
             return this;
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     // Tracks both mutations to the list and changes to the items in the list.
@@ -506,16 +478,10 @@ namespace Signals
             return _list.GetEnumerator();
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-
         public override sealed IList<T> Get()
         {
             return this;
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     // Doesn't track changes of values, only mutations to the dictionary itself
@@ -596,16 +562,10 @@ namespace Signals
             return _dict.ContainsKey(key);
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-
         public override sealed ShallowSignalDictionary<K, V> Get()
         {
             return this;
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
 
         public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _dict.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -729,16 +689,10 @@ namespace Signals
             return _dict.ContainsKey(key);
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-
         public override sealed SignalDictionary<K, V> Get()
         {
             return this;
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
 
         public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => _dict.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -885,16 +839,10 @@ namespace Signals
             return _list.Contains(value);
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
-
         public override sealed IndexedSignalDictionary<K, V> Get()
         {
             return this;
         }
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
 
         public IEnumerator GetEnumerator() => _dict.GetEnumerator();
     }

--- a/Assets/Fiber/Packages/Signals/Runtime/StaticSignals.cs
+++ b/Assets/Fiber/Packages/Signals/Runtime/StaticSignals.cs
@@ -16,12 +16,7 @@ namespace Signals
             _value = value;
         }
 
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
         public override sealed T Get() => _value;
-        public override sealed bool IsDirty(byte otherDirtyBit) => DirtyBit != otherDirtyBit;
     }
 
     public static class StaticSignals

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Breakpoints.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Breakpoints.cs
@@ -134,14 +134,5 @@ namespace SilkUI
         }
 
         public override BreakpointTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 }

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Color.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Color.cs
@@ -107,11 +107,6 @@ namespace SilkUI
         }
 
         public override Role Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
         public Element GetElement(ElementType elementType)
         {
             return elementType switch
@@ -131,11 +126,6 @@ namespace SilkUI
         public bool IsElementEmpty(ElementType elementType)
         {
             return GetElement(elementType).IsEmpty();
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
         }
     }
 
@@ -213,15 +203,6 @@ namespace SilkUI
         }
 
         public override Modifiers<T> Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 
     public class ColorModifiers : Modifiers<StyleColor>

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Icon.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Icon.cs
@@ -62,14 +62,5 @@ namespace SilkUI
         }
 
         public override IconTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 }

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Spacing.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Spacing.cs
@@ -34,15 +34,6 @@ namespace SilkUI
         }
 
         public override SpacingTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 
     public enum BorderWidthType
@@ -121,15 +112,6 @@ namespace SilkUI
         }
 
         public override BorderWidthTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 
     public enum TextOutlineType
@@ -184,14 +166,5 @@ namespace SilkUI
         }
 
         public override TextOutlineTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 }

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Typography.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/DesignTokens.Typography.cs
@@ -81,10 +81,6 @@ namespace SilkUI
         }
 
         public override TypographyTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
 
         public TypographyTypeTokens GetTypographyTypeTokens(TypographyType typographyType)
         {
@@ -105,11 +101,6 @@ namespace SilkUI
                 TypographyType.Overline => Overline,
                 _ => null,
             };
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
         }
     }
 
@@ -162,14 +153,5 @@ namespace SilkUI
         }
 
         public override TypographyTypeTokens Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
     }
 }

--- a/Assets/Fiber/Packages/SilkUI/Runtime/Theme/SilkUI.Theme.cs
+++ b/Assets/Fiber/Packages/SilkUI/Runtime/Theme/SilkUI.Theme.cs
@@ -52,15 +52,6 @@ namespace SilkUI
         }
 
         public override Theme Get() => this;
-        public override bool IsDirty(byte otherDirtyBit)
-        {
-            return DirtyBit != otherDirtyBit;
-        }
-
-        protected override sealed void OnNotifySignalUpdate()
-        {
-            _dirtyBit++;
-        }
 
         public ColorModifiers GetColorModifiers(string role, ElementType elementType, string subRole, string variant = null)
         {


### PR DESCRIPTION
Avoid calling virtual functions at all cost, especially for hot paths like `Get()`.